### PR TITLE
Add deployment for docs-dev

### DIFF
--- a/.github/workflows/build-the-docs.yml
+++ b/.github/workflows/build-the-docs.yml
@@ -3,10 +3,10 @@ name: "Build the docs"
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ "master", "docs-dev" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ "master", "docs-dev" ]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -63,7 +63,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ github.ref == 'refs/heads/master' && steps.deployment.outputs.page_url || format('{0}/{1}', steps.deployment.outputs.page_url , 'docs-dev') }}
     runs-on: ubuntu-latest
     needs: build-docs
     steps:


### PR DESCRIPTION
Is this enough?

Should we also tell Sphynx at build time that the site will be hosted in a subfolder and not at the root?