### PR TITLE
Allow scalars in the json file

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -215,13 +215,13 @@ sections of the JSON schema are optional if the implementation does not require 
     },
     "type": "object",
     "properties": {
-        "datasets": {
+        "data": {
             "type": "array",
             "items": {
                 "allOf": [ { "$ref": "#/$defs/identifiable" } ],
                 "properties": {
                     "source": { "type": "string" },
-                    "structure": { "$ref": "#/$defs/vtl-id" }
+                    "metadata": { "$ref": "#/$defs/vtl-id" }
                 },
                 "required": [ "structure" ]
             }


### PR DESCRIPTION
This patch allows the json metadata file to also represent scalar values. It's a terminology change to make the change more evident.