### PR TITLE
Allow scalar data sources in json metadata descriptor

### DIFF
--- a/v2.1/docs/Technical_Notes.md
+++ b/v2.1/docs/Technical_Notes.md
@@ -220,10 +220,15 @@ sections of the JSON schema are optional if the implementation does not require 
             "items": {
                 "allOf": [ { "$ref": "#/$defs/identifiable" } ],
                 "properties": {
-                    "metadata": { "$ref": "#/$defs/vtl-id" },
                     "source": { "type": "string" }
+                    "structure": { "$ref": "#/$defs/vtl-id" },
+                    "valuedomain": { "$ref": "#/$defs/vtl-id" },
                 },
-                "required": [ "metadata" ]
+                "required": [ "metadata" ],
+                "oneOf": [
+                    { "required": [ "structure" ] },
+                    { "required": [ "valuedomain" ] }
+                ]
             }
         },
         "structures": {

--- a/v2.1/docs/Technical_Notes.md
+++ b/v2.1/docs/Technical_Notes.md
@@ -215,15 +215,15 @@ sections of the JSON schema are optional if the implementation does not require 
     },
     "type": "object",
     "properties": {
-        "datasets": {
+        "data": {
             "type": "array",
             "items": {
                 "allOf": [ { "$ref": "#/$defs/identifiable" } ],
                 "properties": {
-                    "source": { "type": "string" },
-                    "structure": { "$ref": "#/$defs/vtl-id" }
+                    "metadata": { "$ref": "#/$defs/vtl-id" },
+                    "source": { "type": "string" }
                 },
-                "required": [ "structure" ]
+                "required": [ "metadata" ]
             }
         },
         "structures": {


### PR DESCRIPTION
This patch allows the json metadata file to also represent scalar values. It's a terminology change to make the change more evident.