### PR TITLE
Adjust figure styles in the user manual

### DIFF
--- a/v2.1/docs/user_manual/operators.rst
+++ b/v2.1/docs/user_manual/operators.rst
@@ -1046,23 +1046,21 @@ Measures will be used:
 
 .. uml::
 
-    @startsalt
+    @startmindmap
 
-        {
-            {T
-                + **Basic Scalar Types**                 **Default Measure Variable**
-                ++ String                            string_var
-                ++ Number                            num_var
-                +++ Integer                          int_var
-                ++++ Natural                         nat_var
-                ++ Time                              time_var
-                +++ Time-instant                     date_var
-                +++ Time-period                      period_var
-                ++ Boolean                           bool_var
-            }
-        }
+    title Basic scalar types with default measure variables
 
-    @endsalt
+        * Scalar
+        ** <i>String</i> (string_var)
+        ** <i>Number</i> (num_var)
+        *** <i>Integer</i> (int_var)
+		**** <i>Natural</i> (nat_var)
+        ** <i>Time</i> (time_var)
+        *** <i>Time-instant</i> (date_var)
+        *** <i>Time-period</i> (period_var)
+        ** <i>Boolean</i> (bool_var)
+
+    @endmindmap
 
 In some cases, in the examples of the Manuals, the default Boolean
 variable is also called “condition”.

--- a/v2.1/docs/user_manual/types.rst
+++ b/v2.1/docs/user_manual/types.rst
@@ -278,22 +278,8 @@ The hierarchical tree of the basic scalar types is the following:
 
     @endmindmap
 
-.. uml::
-
-    @startwbs
-        * <i>Scalar</i>
-        ** <i>String</i>
-        ** <i>Number</i>
-        *** <i>Integer</i>
-        ** <i>Time</i>
-        *** <i>Date</i>
-        *** <i>Time period</i>
-        ** <i>Duration</i>
-        ** <i>Boolean</i>
-	@endwbs	
-
-A scalar Value of type **string** is a sequence of alphanumeric
-characters of any length. On scalar Values of type *string*, the string
+A Scalar Value of type **string** is a sequence of alphanumeric
+characters of any length. On Scalar Values of type *string*, the string
 operations can be allowed, like concatenation of strings, split of
 strings, extraction of a part of a string (substring) and so on.
 


### PR DESCRIPTION
Switch to mind map style for the tree of scalar types (chapter on VTL types) and for the tree of default measure variables (chapter on VTL operators).