### PR TITLE
VTL Metadata versioning in json schema

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -215,6 +215,14 @@ sections of the JSON schema are optional if the implementation does not require 
     },
     "type": "object",
     "properties": {
+        "versioning": {
+            "type": "object",
+            "properties": {
+                "vtl": { const: "2.1" },
+                "schemaver": { const: "1.0.0" }
+            },
+            "required": [ "vtlmajor", "schemaver" ]
+        },
         "datasets": {
             "type": "array",
             "items": {


### PR DESCRIPTION
This adds semantic versioning to the Json schema for VTL metadata described in the guidelines.
The versioning, as of this proposal, is not mandatory to include in the metadata file, but if used both attributes should be specified.