### PR TITLE
Updates to build-the-docs.yml

### DIFF
--- a/.github/workflows/build-the-docs.yml
+++ b/.github/workflows/build-the-docs.yml
@@ -24,6 +24,7 @@ jobs:
   build-docs:
     name: build-docs
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '#no-gha') }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -66,6 +67,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build-docs
+    if: ${{ github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '#no-gha') }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Edits to the gha file so that:
- it's possible to avoid to run the gha if `#no-gha` is contained in the commit msg;
- publishing to ghp is skipped if the action is triggered by a PR.