### PR TITLE
Prevent italic formatting of code in examples. Fix #550

### DIFF
--- a/v2.2/docs/templates/examples
+++ b/v2.2/docs/templates/examples
@@ -20,6 +20,7 @@ Input **{{ input.name | upper }}** (see `structure <{{ repourl_ex |replace(" ", 
 Example {{ example.i }}
 ^^^^^^^^^^^^^^^^
 .. literalinclude:: examples/{{ example.name }}.vtl
+   :language: text
 
 results in (see `structure <{{ repourl_ex |replace(" ", "%20") }}/{{ example.folder|replace(" ", "%20")|replace("\\", "/")}}/{{ example.name }}.json>`__\):
 


### PR DESCRIPTION
This fixes the issue #550 