### PR TITLE
Documentation updates preview in PR

### DIFF
--- a/.github/workflows/build-the-docs.yml
+++ b/.github/workflows/build-the-docs.yml
@@ -21,9 +21,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-docs:
-    name: build-docs
+  build-index:
+    name: build-index
     runs-on: ubuntu-latest
+    needs: build-manuals
     if: ${{ !contains(github.event.head_commit.message, '#no-gha') }}
     steps:
     - uses: actions/checkout@v4
@@ -43,24 +44,66 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         wget -O /tmp/plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2025.9/plantuml-1.2025.9.jar
-    - name: Sphynx build
+    - name: Sphynx build index
       run: |
         sphinx-build -M html docs outputdir/
-        sphinx-build -M html v2.1/docs outputdir/2.1/
-        sphinx-build -b pdf v2.1/docs outputdir/2.1/html/pdf
-        sphinx-build -M html v2.2/docs outputdir/2.2/
-        sphinx-build -b pdf v2.2/docs outputdir/2.2/html/pdf
         mv outputdir/html/* outputdir/
-    - name: Fix permissions
-      run: |
         chmod -c -R +rX "outputdir/" | while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
-    # Create and upload Pages artifact from docs dir
-    - name: Upload Pages artifact
+    - name: Download manuals artifacts (html + pdf)
+      uses: actions/download-artifact@v7
+      with:
+        pattern: docs-*
+        path: outputdir
+    - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: ./outputdir
+        path: outputdir
+
+  build-manuals:
+    name: build-manuals
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '#no-gha') }}
+    strategy:
+      matrix:
+        version: [ "2.1", "2.2" ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Setup Java 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: 8
+        distribution: "temurin"
+    - name: Install dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install graphviz texlive-font-utils libcairo2-dev -y
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        wget -O /tmp/plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2025.9/plantuml-1.2025.9.jar
+    - name: Build html v${{ matrix.version }}
+      run: sphinx-build -M html v${{ matrix.version }}/docs outputdir/${{ matrix.version }}/
+    - name: Upload html v${{ matrix.version }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-${{ matrix.version }}-html
+        if-no-files-found: error
+        path: |
+          outputdir/${{ matrix.version }}/html
+          !outputdir/${{ matrix.version }}/html/pdf
+    - name: Build pdf v${{ matrix.version }}
+      run: sphinx-build -b pdf v${{ matrix.version }}/docs outputdir/${{ matrix.version }}/html/pdf
+    - name: Upload pdf ${{ matrix.version }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-${{ matrix.version }}-pdf
+        if-no-files-found: error
+        path: outputdir/${{ matrix.version }}/html/pdf/**/*.pdf
 
   # Deployment job
   deploy:
@@ -68,7 +111,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build-docs
+    needs: build-index
     if: ${{ github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '#no-gha') }}
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This automatically creates zipfiles containing preview html/pdf versions of the manuals for each version built from submitted PR.

Artifact zip files are downloadable from the "build the docs / build index" action in the "Checks" section at the bottom of each PR page, when the checks are complete.
