### PR TITLE
Fix links in README for VTL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The specifications for exchanging VTL validation rules in SDMX messages, for sto
 --- 
 # VTL Versions
 
-The current official version of the language is [v2.1](https://github.com/sdmx-twg/vtl/tree/master/v2.1) and it includes:
+The current official version of the language is [v2.1](https://sdmx-twg.github.io/vtl/2.1/sdmx-twg/vtl/tree/master/v2.1) and it includes:
 
-* [User Manual](https://sdmx-twg.github.io/vtl/2.1/html/user_manual/index.html) highlighting the main characteristics of VTL, its core assumptions and the information model the language is based on;
-* [Reference Manual](https://sdmx-twg.github.io/vtl/2.1/html/reference_manual/index.html), describing the full library of operators ordered by category, with examples;
+* [User Manual](https://sdmx-twg.github.io/vtl/2.1/user_manual/index.html) highlighting the main characteristics of VTL, its core assumptions and the information model the language is based on;
+* [Reference Manual](https://sdmx-twg.github.io/vtl/2.1/reference_manual/index.html), describing the full library of operators ordered by category, with examples;
 * EBNF notation (Extended Backus-Naur Form) grammar, which is the technical notation to be used as a test bed for all the examples throughout the document: files [Vtl.g4](https://github.com/sdmx-twg/vtl/blob/master/v2.1/src/main/antlr4/org/sdmx/vtl/Vtl.g4) & [VtlTokens.g4](https://github.com/sdmx-twg/vtl/blob/master/v2.1/src/main/antlr4/org/sdmx/vtl/VtlTokens.g4)
 * [Technical Notes document](https://github.com/sdmx-twg/vtl/blob/master/v2.1/docs/Technical_Notes.md), to support VTL implementation


### PR DESCRIPTION
Updated links in the README to point to the correct documentation.