### PR TITLE
Update group all to include delimiter

### DIFF
--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -445,7 +445,7 @@ limitClauseItem:
 /* ------------------------------------------------------------ GROUPING CLAUSE ------------------------------------*/
 groupingClause:
     GROUP op=(BY | EXCEPT) componentID (COMMA componentID)* ( TIME_AGG LPAREN STRING_CONSTANT (COMMA delim=(FIRST|LAST))? RPAREN )?     # groupByOrExcept
-    | GROUP ALL ( TIME_AGG LPAREN STRING_CONSTANT RPAREN )?                                                               # groupAll
+    | GROUP ALL ( TIME_AGG LPAREN STRING_CONSTANT (COMMA delim=(FIRST|LAST))? RPAREN )?                                                 # groupAll
   ;
 
 havingClause:


### PR DESCRIPTION
Closes #680 

Updates the grammar to ensure the delimiter is also used in the group all time_agg