### PR TITLE
Allow varID where constants are required (6 grammar positions)

### DIFF
--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -219,8 +219,8 @@ timeOperators:
     PERIOD_INDICATOR LPAREN expr? RPAREN                                                                                                # periodAtom
     | FILL_TIME_SERIES LPAREN expr (COMMA op=(SINGLE|ALL))? RPAREN                                                                         # fillTimeAtom
     | op=(FLOW_TO_STOCK | STOCK_TO_FLOW) LPAREN expr RPAREN	                                                                            # flowAtom
-    | TIMESHIFT LPAREN expr COMMA signedInteger RPAREN                                                                                  # timeShiftAtom
-    | TIME_AGG LPAREN periodIndTo=STRING_CONSTANT (COMMA periodIndFrom=(STRING_CONSTANT| OPTIONAL ))? (COMMA op=optionalExpr)? (COMMA delim=(FIRST|LAST))? RPAREN     # timeAggAtom
+    | TIMESHIFT LPAREN expr COMMA (intShift=signedInteger | varShift=varID) RPAREN                                                      # timeShiftAtom
+    | TIME_AGG LPAREN (periodIndToVar=varID | periodIndToConst=STRING_CONSTANT) (COMMA periodIndFrom=(STRING_CONSTANT| OPTIONAL ))? (COMMA op=optionalExpr)? (COMMA delim=(FIRST|LAST))? RPAREN     # timeAggAtom
     | CURRENT_DATE LPAREN RPAREN                                                                                                        # currentDateAtom
     | DATEDIFF LPAREN dateFrom=expr COMMA dateTo=expr RPAREN                    # dateDiffAtom
     | DATEADD LPAREN op=expr COMMA shiftNumber=expr COMMA periodInd=expr RPAREN # dateAddAtom
@@ -238,8 +238,8 @@ timeOperatorsComponent:
     PERIOD_INDICATOR LPAREN exprComponent? RPAREN                                                                                               # periodAtomComponent
     | FILL_TIME_SERIES LPAREN exprComponent (COMMA op=(SINGLE|ALL))? RPAREN                                                                        # fillTimeAtomComponent
     | op=(FLOW_TO_STOCK | STOCK_TO_FLOW) LPAREN exprComponent RPAREN	                                                                                    # flowAtomComponent
-    | TIMESHIFT LPAREN exprComponent COMMA signedInteger RPAREN                                                                                 # timeShiftAtomComponent
-    | TIME_AGG LPAREN periodIndTo=STRING_CONSTANT (COMMA periodIndFrom=(STRING_CONSTANT| OPTIONAL ))? (COMMA op=optionalExprComponent)? (COMMA delim=(FIRST|LAST))? RPAREN    # timeAggAtomComponent
+    | TIMESHIFT LPAREN exprComponent COMMA (intShift=signedInteger | varShift=varID) RPAREN                                                     # timeShiftAtomComponent
+    | TIME_AGG LPAREN (periodIndToVar=varID | periodIndToConst=STRING_CONSTANT) (COMMA periodIndFrom=(STRING_CONSTANT| OPTIONAL ))? (COMMA op=optionalExprComponent)? (COMMA delim=(FIRST|LAST))? RPAREN    # timeAggAtomComponent
     | CURRENT_DATE LPAREN RPAREN                                                                                                               # currentDateAtomComponent
     | DATEDIFF LPAREN dateFrom=exprComponent COMMA dateTo=exprComponent RPAREN           # dateDiffAtomComponent
     | DATEADD LPAREN op=exprComponent COMMA shiftNumber=exprComponent COMMA periodInd=exprComponent RPAREN # dateAddAtomComponent
@@ -321,7 +321,7 @@ aggrOperatorsGrouping:
         | FIRST_VALUE
         | LAST_VALUE)
         LPAREN expr OVER LPAREN (partition=partitionByClause? orderBy=orderByClause? windowing=windowingClause?)RPAREN RPAREN       #anSimpleFunction
-    | op=(LAG |LEAD)  LPAREN expr (COMMA offset=signedInteger(COMMA defaultValue=scalarItem)?)?  OVER  LPAREN (partition=partitionByClause? orderBy=orderByClause)   RPAREN RPAREN    # lagOrLeadAn
+    | op=(LAG |LEAD)  LPAREN expr (COMMA (intOffset=signedInteger | varOffset=varID)(COMMA defaultValue=scalarItem)?)?  OVER  LPAREN (partition=partitionByClause? orderBy=orderByClause)   RPAREN RPAREN    # lagOrLeadAn
     | op=RATIO_TO_REPORT LPAREN expr OVER  LPAREN (partition=partitionByClause) RPAREN RPAREN                                                                           # ratioToReportAn
 ;
 
@@ -339,7 +339,7 @@ aggrOperatorsGrouping:
          | FIRST_VALUE
          | LAST_VALUE)
          LPAREN exprComponent OVER LPAREN (partition=partitionByClause? orderBy=orderByClause? windowing=windowingClause?)RPAREN RPAREN       #anSimpleFunctionComponent
-    | op=(LAG |LEAD)  LPAREN exprComponent (COMMA offset=signedInteger(defaultValue=scalarItem)?)?  OVER  LPAREN (partition=partitionByClause? orderBy=orderByClause)   RPAREN RPAREN   # lagOrLeadAnComponent
+    | op=(LAG |LEAD)  LPAREN exprComponent (COMMA (intOffset=signedInteger | varOffset=varID)(defaultValue=scalarItem)?)?  OVER  LPAREN (partition=partitionByClause? orderBy=orderByClause)   RPAREN RPAREN   # lagOrLeadAnComponent
     | op=RANK LPAREN  OVER  LPAREN (partition=partitionByClause? orderBy=orderByClause) RPAREN RPAREN                                                                           # rankAnComponent
     | op=RATIO_TO_REPORT LPAREN exprComponent OVER  LPAREN (partition=partitionByClause) RPAREN RPAREN                                                                          # ratioToReportAnComponent
 ;
@@ -371,7 +371,7 @@ calcClauseItem:
 
 /*SUBSPACE CLAUSE*/
 subspaceClauseItem:
-  componentID  EQ  scalarItem
+  componentID  EQ  (varID | scalarItem)
 ;
 
 scalarItem:
@@ -434,8 +434,8 @@ signedNumber:
 ;
 
 limitClauseItem:
-    signedInteger dir=PRECEDING
-    | signedInteger dir=FOLLOWING
+    (intLimit=signedInteger | varLimit=varID) dir=PRECEDING
+    | (intLimit=signedInteger | varLimit=varID) dir=FOLLOWING
     | CURRENT DATA POINT
     | UNBOUNDED dir=PRECEDING
     | UNBOUNDED dir=FOLLOWING
@@ -444,8 +444,8 @@ limitClauseItem:
 /*--------------------------------------------END ANALYTIC CLAUSE -----------------------------------------------*/
 /* ------------------------------------------------------------ GROUPING CLAUSE ------------------------------------*/
 groupingClause:
-    GROUP op=(BY | EXCEPT) componentID (COMMA componentID)* ( TIME_AGG LPAREN STRING_CONSTANT (COMMA delim=(FIRST|LAST))? RPAREN )?     # groupByOrExcept
-    | GROUP ALL ( TIME_AGG LPAREN STRING_CONSTANT (COMMA delim=(FIRST|LAST))? RPAREN )?                                                 # groupAll
+    GROUP op=(BY | EXCEPT) componentID (COMMA componentID)* ( TIME_AGG LPAREN (periodVar=varID | periodConst=STRING_CONSTANT) (COMMA delim=(FIRST|LAST))? RPAREN )?     # groupByOrExcept
+    | GROUP ALL ( TIME_AGG LPAREN (periodVar=varID | periodConst=STRING_CONSTANT) (COMMA delim=(FIRST|LAST))? RPAREN )?                                                 # groupAll
   ;
 
 havingClause:


### PR DESCRIPTION
## Summary

Widens six grammar positions to accept either a literal or a `varID` (a name resolving to a scalar), so scripts can parameterise these positions with a top-level scalar assignment or pass a UDO parameter into them.

The change is **strictly additive** — every script that parses today continues to parse identically.

## Changes

| # | Position | Today | Proposed |
|---|---|---|---|
| 1 | `time_agg(periodIndTo, …)` | `STRING_CONSTANT` | `varID` ∣ `STRING_CONSTANT` |
| 2 | `time_agg(periodTo, …)` in `group by` / `group all` | `STRING_CONSTANT` | `varID` ∣ `STRING_CONSTANT` |
| 3 | Analytic windowing offsets (`data points between … preceding/following`) | `signedInteger` | `varID` ∣ `signedInteger` |
| 4 | `sub Comp = value` (subspace clause) | `scalarItem` | `varID` ∣ `scalarItem` |
| 5 | `timeshift(expr, shift)` shift count | `signedInteger` | `varID` ∣ `signedInteger` |
| 6 | `lag` / `lead` offset | `signedInteger` | `varID` ∣ `signedInteger` |

`time_agg`'s `periodIndFrom` is **deliberately excluded**: widening it collides with the existing short form `time_agg("A", DS_1)` under ANTLR4 LL(*), which would silently mis-bind the operand. A future proposal can lift this with either a mandatory `_` placeholder or a semantic predicate.

## Examples

### Top-level scalar feeding `time_agg`

```vtl
sc_1 := "A";

DS_r  <- sum(DS_T group all time_agg(sc_1));
DS_r2 <- DS_T[aggr Me_1 := sum(Me_1) group all time_agg(sc_1)];
```

### Top-level scalar feeding analytic windowing

```vtl
sc_1 := 1;

/* Running sum over the current row plus the previous one within each Id_1 partition */
DS_r <- sum(DS_P over (
              partition by Id_1 order by Id_2
              data points between sc_1 preceding and current data point
            ));

/* Centred window: 2 rows around the current one */
sc_2 := 2;
DS_r2 <- avg(DS_P over (
               partition by Id_1 order by Id_2
               data points between sc_2 preceding and sc_2 following
             ));
```

### Top-level scalar feeding subspace

```vtl
sc_1 := 3;

DS_r <- DS_1[sub Id_1 = sc_1];
```

### Top-level scalar feeding `timeshift`

```vtl
sc_1 := 2;

DS_r <- timeshift(DS_T, sc_1);
```

### Top-level scalar feeding `lag` / `lead`

```vtl
sc_1 := 1;

DS_lag  <- lag(DS_P,  sc_1 over (partition by Id_1 order by Id_2));
DS_lead <- lead(DS_P, sc_1 over (partition by Id_1 order by Id_2));
```

### UDO parameter feeding `time_agg`

```vtl
define operator agg_by_period(ds dataset, p string default "Q")
  returns dataset is
    sum(ds group all time_agg(p))
end operator;

DS_yearly  <- agg_by_period(DS_T, "A");
DS_monthly <- agg_by_period(DS_T, "M");
```

### UDO parameter feeding analytic windowing

```vtl
define operator running(ds dataset, n integer)
  returns dataset is
    sum(ds over (
          partition by Id_1 order by Id_2
          data points between n preceding and current data point
        ))
end operator;

DS_run1 <- running(DS_P, 1);
DS_run3 <- running(DS_P, 3);
```

### UDO parameter feeding subspace

```vtl
define operator pick(ds dataset, target integer)
  returns dataset is
    ds[sub Id_1 = target]
end operator;

DS_one <- pick(DS_1, 3);
```