### PR TITLE
Added changes to viral attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+.venv
 outputdir
 *.jar
 .vscode/

--- a/v2.2/docs/reference_manual/operators/Aggregate and Analytic operators/Aggregate invocation/content.rst
+++ b/v2.2/docs/reference_manual/operators/Aggregate and Analytic operators/Aggregate invocation/content.rst
@@ -173,8 +173,8 @@ Measures are dropped because no aggregation behaviour is specified for them).
 
 For invocation at Data Set level, the Attribute propagation rule is applied. For invocation at Component level,
 the Attributes calculated within the *aggr* clause are maintained in the result; for all the other Attributes that are
-defined as **viral**, the Attribute propagation rule is applied (for the semantics, see the Attribute Propagation Rule
-section in the User Manual).
+defined as **viral**, the Attribute propagation rule is applied (for the semantics, see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`
+and the "Attribute Propagation Rule" section in the User Manual).
 
 As mentioned, the Aggregate invocation at component level can be done within the **aggr** clause, both as part of a
 Join operator and the **aggr** operator (see the parameter *aggrExpr* of those operators), therefore, for a better

--- a/v2.2/docs/reference_manual/operators/Aggregate and Analytic operators/Analytic invocation/content.rst
+++ b/v2.2/docs/reference_manual/operators/Aggregate and Analytic operators/Analytic invocation/content.rst
@@ -195,6 +195,9 @@ for each row, all the Attribute values in the data points present in relative wi
 
 For the invocation at Component level through the **calc** operator or the **calc** clause, the resulting Data Set
 retains all the original components of the input Data Set plus the components explicitly calculated by it (see the calc operator).
+The Attributes calculated within the **calc** clause are maintained in the result; for all the other Attributes that are
+defined as viral, the Attribute propagation rule is applied (for the semantics, see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`
+and the "Attribute Propagation Rule" section in the User Manual).
 
 For the invocation at Component level through the **filter** operator or the **filter** clause, the resulting Data Set
 retains all the original components of the input Data Set (see the filter operator). The scalar value assumed by the 

--- a/v2.2/docs/reference_manual/operators/Clause operators/Aggregation/content.rst
+++ b/v2.2/docs/reference_manual/operators/Clause operators/Aggregation/content.rst
@@ -137,7 +137,7 @@ The operator **aggr** calculates aggregations of dependent Components (Measures 
 sub-expressions at Component level. Each Component is calculated through an independent sub-expression. It is
 possible to specify the role of the calculated Component among **measure**, **attribute**, or **viral attribute**. The
 substring **viral** allows to control the virality of Attributes, if the Attribute propagation rule is adopted (see the
-User Manual). When the role is omitted, the following rule is applied: if the component exists in the operand Data
+User Manual and :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`). When the role is omitted, the following rule is applied: if the component exists in the operand Data
 Set then it maintains its role; if the component does not exist in the operand Data Set then its role is Measure.
 
 The *aggrExpr* sub-expressions are independent of one another, they can only reference Components of the input

--- a/v2.2/docs/reference_manual/operators/Clause operators/Aggregation/content.rst
+++ b/v2.2/docs/reference_manual/operators/Clause operators/Aggregation/content.rst
@@ -166,5 +166,5 @@ If no grouping clause is specified, then all the input Data Points are aggregate
 returns a Data Set that contains a single Data Point and has no Identifiers.
 
 The Attributes calculated through the **aggr** clauses are maintained in the result. For all the other Attributes that
-are defined as **viral**, the Attribute propagation rule is applied (for the semantics, see the Attribute Propagation
-Rule section in the User Manual).
+are defined as **viral**, the Attribute propagation rule is applied (for the semantics, see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`
+and the "Attribute Propagation Rule" section in the User Manual).

--- a/v2.2/docs/reference_manual/operators/Clause operators/Calculation of a Component/content.rst
+++ b/v2.2/docs/reference_manual/operators/Clause operators/Calculation of a Component/content.rst
@@ -72,7 +72,8 @@ The operator calculates new Identifier, Measure or Attribute Components on the b
 Component level. Each Component is calculated through an independent sub-expression. It is possible to specify
 the role of the calculated Component among **measure**, **identifier**, **attribute**, or **viral attribute**, therefore the calc
 clause can be used also to change the role of a Component when possible. The keyword **viral** allows controlling
-the virality of the calculated Attributes (for the attribute propagation rule see the User Manual). When the role is
+the virality of the calculated Attributes (for the attribute propagation rule see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`
+and the User Manual). When the role is
 omitted, the following rule is applied: if the component exists in the operand Data Set then it maintains its role; if
 the component does not exist in the operand Data Set then its role is Measure.
 

--- a/v2.2/docs/reference_manual/operators/Data validation operators/Check hierarchy/content.rst
+++ b/v2.2/docs/reference_manual/operators/Data validation operators/Check hierarchy/content.rst
@@ -99,7 +99,7 @@ Variables and Value Domains”). The operator checks if the relation between the
 fulfilled, giving **true** in positive case and **false** in negative case.
 
 The Attribute propagation rule is applied on each group of Data Points which contributes to the same Data Point
-of the result.
+of the result (see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`).
 
 The behaviours relevant to the different options of the input parameters are the following.
 

--- a/v2.2/docs/reference_manual/operators/General purpose operators/Membership/content.rst
+++ b/v2.2/docs/reference_manual/operators/General purpose operators/Membership/content.rst
@@ -54,8 +54,9 @@ A default conventional name is assigned to the new Measure depending on its type
 if the Measure is `numeric`, `string_var` if it is `string` and so on (the default name can be renamed through
 the **rename** operator if needed).
 
-The Attributes follow the Attribute propagation rule as usual (viral Attributes of `ds` are maintained in the result as 
-viral, non-viral ones are dropped). If `comp` is an Attribute, it follows the Attribute propagation rule too.
+The Attributes follow the Attribute propagation rule as usual (viral Attributes of `ds` are maintained in the result as
+viral, non-viral ones are dropped). If `comp` is an Attribute, it follows the Attribute propagation rule too
+(see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`).
 
 If ds has no Identifier Components (for example is a result of an aggregate invocation), comp must be a Data Set 
 Component of the Data Set ds (a Measure or an Attribute). In this case the operator returns a scalar value equal to

--- a/v2.2/docs/reference_manual/operators/Hierarchical aggregation/Hierarchical roll-up/content.rst
+++ b/v2.2/docs/reference_manual/operators/Hierarchical aggregation/Hierarchical roll-up/content.rst
@@ -102,7 +102,8 @@ Behaviour
 
 The **hierarchy** operator applies the rules of *hr* to *op* as specified in the parameters. The operator returns a Data
 Set with the same Identifiers and the same Measure as *op*. The Attribute propagation rule is applied on the
-groups of Data Points which contribute to the same Data Points of the result.
+groups of Data Points which contribute to the same Data Points of the result
+(see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`).
 
 The behaviours relevant to the different options of the input parameters are the following.
 

--- a/v2.2/docs/reference_manual/operators/Join operators/Cross Join/content.rst
+++ b/v2.2/docs/reference_manual/operators/Join operators/Cross Join/content.rst
@@ -260,4 +260,4 @@ data set. The final result has a size equal to the product of the sizes of each 
 The **Viral Attribute propagation** in the join is the following. The Attributes explicitly calculated through the **calc**
 or **aggr** clauses are maintained unchanged. Other viral attributes, present in exactly one input data set, are also kept
 unchanged. For all the other viral attributes, which are present in multiple data sets, the Attribute propagation rule is
-applied on VDS₂ (see "Attribute Propagation Rule" section in the User Manual).
+applied on VDS₂ (see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes` and the "Attribute Propagation Rule" section in the User Manual).

--- a/v2.2/docs/reference_manual/operators/Join operators/Full Join/content.rst
+++ b/v2.2/docs/reference_manual/operators/Join operators/Full Join/content.rst
@@ -296,4 +296,4 @@ by joining this partial result to the next data set.
 The **Viral Attribute propagation** in the join is the following. The Attributes explicitly calculated through the **calc**
 or **aggr** clauses are maintained unchanged. Other viral attributes, present in exactly one input data set, are also kept
 unchanged. For all the other viral attributes, which are present in multiple data sets, the Attribute propagation rule is
-applied on VDS₂ (see "Attribute Propagation Rule" section in the User Manual).
+applied on VDS₂ (see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes` and the "Attribute Propagation Rule" section in the User Manual).

--- a/v2.2/docs/reference_manual/operators/Join operators/Inner Join/content.rst
+++ b/v2.2/docs/reference_manual/operators/Join operators/Inner Join/content.rst
@@ -288,4 +288,4 @@ the step is repeated by joining this partial result to the next data set.
 The **Viral Attribute propagation** in the join is the following. The Attributes explicitly calculated through the **calc**
 or **aggr** clauses are maintained unchanged. Other viral attributes, present in exactly one input data set, are also kept
 unchanged. For all the other viral attributes, which are present in multiple data sets, the Attribute propagation rule is
-applied on VDS₂ (see "Attribute Propagation Rule" section in the User Manual).
+applied on VDS₂ (see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes` and the "Attribute Propagation Rule" section in the User Manual).

--- a/v2.2/docs/reference_manual/operators/Join operators/Left Join/content.rst
+++ b/v2.2/docs/reference_manual/operators/Join operators/Left Join/content.rst
@@ -289,4 +289,4 @@ to the next data set.
 The **Viral Attribute propagation** in the join is the following. The Attributes explicitly calculated through the **calc**
 or **aggr** clauses are maintained unchanged. Other viral attributes, present in exactly one input data set, are also kept
 unchanged. For all the other viral attributes, which are present in multiple data sets, the Attribute propagation rule is
-applied on VDS₂ (see "Attribute Propagation Rule" section in the User Manual).
+applied on VDS₂ (see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes` and the "Attribute Propagation Rule" section in the User Manual).

--- a/v2.2/docs/reference_manual/typical_behaviour.rst
+++ b/v2.2/docs/reference_manual/typical_behaviour.rst
@@ -22,7 +22,8 @@ In the operations on Data Set, the Operators are meant to be applied by
 default only to the values of the Measures of the input Data Sets,
 leaving the Identifiers unchanged. The Attributes follow by default
 their specific propagation rules, which are described in the User
-Manual.
+Manual (see also :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`
+for the declaration of propagation algorithms).
 
 In the operations on Components, the Operators are meant to be applied
 on the specified components of one input Data Set, in order to calculate
@@ -198,7 +199,8 @@ of the other operand.
 
 For each couple (DP_1, DP_2) and for each Attribute that propagates in
 DP_r, the Attribute value is calculated by applying the proper Attribute
-propagation algorithm on the values of the Attributes of DP_1 and DP_2 .
+propagation algorithm on the values of the Attributes of DP_1 and DP_2
+(see :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`).
 
 As for the data structure, the result Data Set (DS_r) has all the
 Identifiers (with no repetition of common Identifiers) and the Measures
@@ -909,7 +911,8 @@ operators in the Reference Manual).
 The users which want to automatize the propagation of the Attributes’
 Values can optionally enforce a mechanism, called Attribute Propagation
 rule, whose behaviour is explained in the User Manual (see the section
-“Behaviour for Attribute Components”). The adoption of this mechanism is
+“Behaviour for Attribute Components”) and whose declaration is described
+in :doc:`/reference_manual/vtl_dl_rulesets/viral_attributes`. The adoption of this mechanism is
 optional, users are free to allow the attribute propagation rule or not.
 The users that do not want to allow Attribute propagation rules simply
 will not implement what follows.

--- a/v2.2/docs/reference_manual/vtl_dl_rulesets/index.rst
+++ b/v2.2/docs/reference_manual/vtl_dl_rulesets/index.rst
@@ -8,3 +8,4 @@ VTL-DL - Rulesets
 
    datapoint_rulesets
    hierarchical_rulesets
+   viral_attributes

--- a/v2.2/docs/reference_manual/vtl_dl_rulesets/viral_attributes.rst
+++ b/v2.2/docs/reference_manual/vtl_dl_rulesets/viral_attributes.rst
@@ -1,0 +1,215 @@
+#########################################
+define viral propagation
+#########################################
+
+---------
+Semantics
+---------
+
+The **define viral propagation** construct registers the algorithm that
+must be applied whenever an operator propagates the value of a viral
+Attribute. The propagation can be attached either to a Represented
+Variable (i.e., to the Attribute itself) or to the Value Domain used by
+the Attribute and is automatically reused by every operator that states
+that viral Attributes must be propagated. When a propagation rule is
+declared on a Value Domain it acts as the default for all Attributes
+using that Value Domain, unless a more specific rule is defined directly
+on the Attribute’s Represented Variable. It is a semantic error to
+define more than one propagation rule for the same Value Domain or for
+the same Variable.
+
+The input of a propagation rule is a **pair** of values from the viral
+Attribute. The propagation algorithm is a binary operation that is
+associative, commutative, and reflexive. When an operator involves more
+than two operands (e.g., an aggregate function or an N-ary arithmetic
+operation), the propagation rule is applied recursively to the values
+pair by pair. The final result is independent of the order in which the
+pairs are evaluated.
+
+Two modelling families are supported:
+
+* **Enumerated rules.** These rules are intended for Attributes that are
+  based on enumerated Value Domains. They are expressed through ordered
+  **when** … **then** clauses. Each clause describes a combination of
+  input values and the resulting value that shall be produced. The
+  clauses are evaluated in order, but **binary clauses** (specifying a
+  pair of values) always take precedence over **unary clauses**
+  (specifying a single value).
+
+  * A **binary clause** (e.g., ``when "A" and "B" then "C"``) matches
+    if the input pair consists of exactly those two values.
+  * A **unary clause** (e.g., ``when "A" then "A"``) matches if the
+    specified value is present in the input pair (regardless of what the
+    other value is).
+
+  The first matching clause determines the result. To guarantee
+  determinism and associativity, the rule must be defined such that the
+  result is consistent regardless of grouping.
+
+  Optionally, an **else** clause can provide the default result for any
+  combination that is not explicitly listed; when it is absent, missing
+  combinations yield NULL. Every combination of values can be described
+  only once. The use of the **or** operator is not allowed; every
+  combination must be listed explicitly.
+
+* **Aggregate rules.** These rules are meant for Attributes that use
+  non-enumerated Value Domains (for example dates or numbers). The rule
+  simply names the aggregate function that must collapse the set of
+  operand values to a single result. Only a dedicated list of aggregate
+  keywords (**min**, **max**, **sum**, **avg**) can be used so that the
+  propagation stays deterministic and implementation-independent.
+
+Operators do not accept propagation instructions directly: once the
+propagation is defined (either on the Value Domain or on the Variable),
+every operator that propagates viral Attributes must apply that
+definition (e.g., the typical behaviour rules for binary, aggregate,
+analytic, or join operators).
+
+------
+Syntax
+------
+
+**define viral propagation** propagationName **(** vpSignature_ **) is**
+
+    vpClause_
+
+   { **;** vpClause_ }\*
+
+**end viral propagation**
+
+.. _vpSignature:
+
+vpSignature ::= **valuedomain** valueDomain | **variable** variable
+
+.. _vpClause:
+
+vpClause ::= enumeratedClause_ | aggregationClause_ | defaultClause_
+
+.. _enumeratedClause:
+
+enumeratedClause ::= { ruleName **:** } **when** enumerationCondition_ **then** vpResult
+
+.. _aggregationClause:
+
+aggregationClause ::= **aggregate** aggregateFunction_
+
+.. _defaultClause:
+
+defaultClause ::= **else** vpResult
+
+.. _enumerationCondition:
+
+enumerationCondition ::= enumerationTerm_ [ **and** enumerationTerm_ ]
+
+.. _enumerationTerm:
+
+enumerationTerm ::= scalarLiteral
+
+.. _aggregateFunction:
+
+aggregateFunction ::= **min** | **max** | **sum** | **avg**
+
+--------------------
+Syntax description
+--------------------
+
+.. list-table::
+
+   * - propagationName
+     - the name assigned to the propagation definition. It can be used
+       to reference the rule in documentation or metadata repositories.
+   * - *vpSignature*
+     - the signature of the propagation definition. It can target either
+       a Value Domain or a Represented Variable. When a Value Domain is
+       specified, every Attribute using that Value Domain inherits the
+       propagation unless it defines its own Variable-level rule.
+   * - valueDomain
+     - the Value Domain for which the propagation is defined. Only one
+       propagation definition can exist for the same Value Domain.
+   * - variable
+     - the Represented Variable owning the viral Attribute. If more than
+       one propagation definition is declared for the same Variable, a
+       semantic error is raised. Variable-level definitions override any
+       Value Domain rule that might exist for the Attribute.
+   * - *vpClause*
+     - a clause that participates in the definition. Clauses are
+       evaluated in the order in which they are written. Aggregation
+       clauses cannot be mixed with enumerated clauses: a propagation
+       uses either a single aggregation clause or a sequence of
+       enumerated clauses (plus an optional default clause).
+   * - *enumeratedClause*
+     - describes a combination of input values (a pair or a single value).
+       The clause is triggered when the input pair matches the condition.
+       Binary clauses (two values) are checked before unary clauses
+       (one value).
+   * - *enumerationCondition*
+     - specifies the values to match. It can be a single value (unary)
+       or two values separated by **and** (binary).
+   * - vpResult
+     - the literal value that must be propagated when the clause is
+       satisfied. It must belong to the same Value Domain as the viral
+       Attribute unless NULL is explicitly desired.
+   * - *defaultClause*
+     - an optional fallback clause triggered after all other
+       enumerated clauses when none of them matches. If omitted and no
+       enumerated clause matches, NULL is propagated.
+   * - *aggregationClause*
+     - specifies that the viral Attribute uses a non-enumerated Value
+       Domain and that the input set must be reduced by applying the
+       indicated aggregate function. Only one aggregation clause is
+       allowed inside a propagation definition.
+   * - aggregateFunction
+     - the keyword naming the allowed aggregate to be applied on the
+       input set: **min**, **max**, **sum**, or **avg**. The semantics of
+       these aggregates follow the standard VTL definitions.
+
+--------
+Examples
+--------
+
+Enumerated Attribute with strict priority (the CL_CONF list with
+``C > N > F``):
+
+::
+
+   define viral propagation CONF_priority (variable CONF) is
+      when "C" then "C";
+      when "N" then "N";
+      else "F"
+   end viral propagation
+
+Enumerated Attribute defined once for the Value Domain so that every
+Attribute using *CL_OBS_STATUS* inherits it. Note that all combinations
+are listed explicitly:
+
+::
+
+   define viral propagation OBS_STATUS_default (valuedomain CL_OBS_STATUS) is
+      when "M" then "M";
+      when "L" then "L";
+      when "F" then "F";
+      when "E" then "F";
+      when "Q" and "P" then "Q";
+      else "A"
+   end viral propagation
+
+Enumerated Attribute where the combination of input values produces a
+new code (computed missing status). The binary rule ``"C" and "M"``
+takes precedence over the unary rule ``"M"``:
+
+::
+
+   define viral propagation COMPUTED_missing (variable COMPUTED) is
+      when "C" and "M" then "N";
+      when "M" then "M";
+      else " "
+   end viral propagation
+
+Non-enumerated Attribute where the most restrictive embargo time has to
+prevail across operations:
+
+::
+
+   define viral propagation EMBARGO_time (variable EMBARGO_TIME) is
+      aggregate max
+   end viral propagation

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -141,6 +141,26 @@ defOperators:
     DEFINE OPERATOR operatorID LPAREN (parameterItem (COMMA parameterItem)*)? RPAREN (RETURNS outputParameterType)? IS (expr) END OPERATOR        # defOperator
     | DEFINE DATAPOINT RULESET rulesetID LPAREN rulesetSignature RPAREN IS ruleClauseDatapoint END DATAPOINT RULESET                            # defDatapointRuleset
     | DEFINE HIERARCHICAL RULESET rulesetID LPAREN hierRuleSignature RPAREN IS ruleClauseHierarchical  END HIERARCHICAL RULESET                 # defHierarchical
+    | DEFINE VIRAL PROPAGATION varID LPAREN vpSignature RPAREN IS vpBody END VIRAL PROPAGATION                                                  # defViralPropagation
+;
+
+vpSignature:
+    VALUE_DOMAIN varID
+    | VARIABLE varID
+;
+
+vpBody:
+    vpClause (EOL vpClause)*
+;
+
+vpClause:
+    (IDENTIFIER COLON)? WHEN vpCondition THEN constant    # enumeratedVpClause
+    | AGGREGATE (MIN | MAX | SUM | AVG)                    # aggregationVpClause
+    | ELSE constant                                        # defaultVpClause
+;
+
+vpCondition:
+    constant (AND constant)?
 ;
 
 /* --------------------------------------------END DEFINE FUNCTIONS------------------------------------------------- */

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -145,8 +145,7 @@ defOperators:
 ;
 
 vpSignature:
-    VALUE_DOMAIN varID
-    | VARIABLE varID
+    (VARIABLE | VALUE_DOMAIN) IDENTIFIER
 ;
 
 vpBody:

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -154,7 +154,7 @@ vpBody:
 
 vpClause:
     (IDENTIFIER COLON)? WHEN vpCondition THEN constant    # enumeratedVpClause
-    | AGGREGATE (MIN | MAX | SUM | AVG)                    # aggregationVpClause
+    | AGGREGATE_KW (MIN | MAX | SUM | AVG)                 # aggregationVpClause
     | ELSE constant                                        # defaultVpClause
 ;
 

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/VtlTokens.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/VtlTokens.g4
@@ -162,6 +162,7 @@ POINT               : 'point';
 POINTS              : 'points';
 POWER               : 'power';
 PRECEDING           : 'preceding';
+PROPAGATION         : 'propagation';
 RANDOM              : 'random';
 RANGE               : 'range';
 RANK                : 'rank';

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/VtlTokens.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/VtlTokens.g4
@@ -32,6 +32,7 @@ SINGLE_QUOTE : '\'';
 // Keyword tokens
 ABS                 : 'abs';
 AGGREGATE           : 'aggr';
+AGGREGATE_KW        : 'aggregate';
 ALL                 : 'all';
 ALL_MEASURES        : 'all_measures';
 ALWAYS_NULL         : 'always_null';


### PR DESCRIPTION
Closes #598

## Summary

Adds the `define viral propagation` construct to the VTL 2.2 grammar and Reference Manual, mirroring the changes already implemented in [vtlengine#631](https://github.com/sdmx-twg/vtl-engine/pull/631) (Fix #510).

## Grammar (`v2.2/src/main/antlr4/org/sdmx/vtl/`)

- **VtlTokens.g4** — new `PROPAGATION : 'propagation';` token.
- **Vtl.g4** — new `defViralPropagation` alternative on `defOperators` plus four supporting rules: `vpSignature`, `vpBody`, `vpClause` (with `enumeratedVpClause` / `aggregationVpClause` / `defaultVpClause` labels), and `vpCondition`.

Example:

```vtl
define viral propagation MyProp (variable Var_1) is
    when "A" then "X";
    when "B" and "C" then "Y";
    else "Z"
end viral propagation;
```

## Reference Manual (`v2.2/docs/`)

- New page **`reference_manual/vtl_dl_rulesets/viral_attributes.rst`** describing semantics, syntax, parameters, and examples of `define viral propagation`. Ported from `origin/Feat/viral-attributes`.
- **`reference_manual/vtl_dl_rulesets/index.rst`** — `viral_attributes` added to the toctree.
- `:doc:` cross-links to the new page added across the Reference Manual wherever the Attribute Propagation rule is invoked:
  - **Join operators**: Inner / Left / Full / Cross
  - **Aggregate and Analytic operators**: Aggregate invocation / Analytic invocation
  - **Clause operators**: Aggregation (two sites) / Calculation of a Component
  - **General purpose / Data validation / Hierarchical aggregation**: Membership / Check hierarchy / Hierarchical roll-up
  - **`typical_behaviour.rst`** (3 sites: intro, binary-on-DataSet section where the propagation algorithm is explicitly invoked, and the dedicated "Attribute propagation" section) — covers the binary/unary operator path, since binary operators have no per-operator content.rst describing propagation.

Negative references ("Attribute propagation … is not applied" on Set, Time, and time-series operators) were left untouched.

## Misc

- `.gitignore` now excludes `.venv` (used for local Sphinx builds).