### PR TITLE
Restrict 2.2 viral propagation body to one aggregate or enumerated clauses

### DIFF
--- a/v2.2/docs/reference_manual/vtl_dl_rulesets/viral_attributes.rst
+++ b/v2.2/docs/reference_manual/vtl_dl_rulesets/viral_attributes.rst
@@ -71,15 +71,18 @@ Syntax
 
 **define viral propagation** propagationName **(** vpSignature_ **) is**
 
-    vpClause_
-
-   { **;** vpClause_ }\*
+    vpBody_
 
 **end viral propagation**
 
 .. _vpSignature:
 
 vpSignature ::= **valuedomain** valueDomain | **variable** variable
+
+.. _vpBody:
+
+vpBody ::= enumeratedClause_ { **;** enumeratedClause_ }\* [ **;** defaultClause_ ]
+         | aggregationClause_
 
 .. _vpClause:
 

--- a/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
+++ b/v2.2/src/main/antlr4/org/sdmx/vtl/Vtl.g4
@@ -149,13 +149,20 @@ vpSignature:
 ;
 
 vpBody:
-    vpClause (EOL vpClause)*
+    enumeratedVpClause (EOL enumeratedVpClause)* (EOL defaultVpClause)?
+    | aggregationVpClause
 ;
 
-vpClause:
-    (IDENTIFIER COLON)? WHEN vpCondition THEN constant    # enumeratedVpClause
-    | AGGREGATE_KW (MIN | MAX | SUM | AVG)                 # aggregationVpClause
-    | ELSE constant                                        # defaultVpClause
+enumeratedVpClause:
+    (IDENTIFIER COLON)? WHEN vpCondition THEN constant
+;
+
+aggregationVpClause:
+    AGGREGATE_KW (MIN | MAX | SUM | AVG)
+;
+
+defaultVpClause:
+    ELSE constant
 ;
 
 vpCondition:

--- a/v2.2/src/test/resources/org/sdmx/vtl/NegativeTests.vtl
+++ b/v2.2/src/test/resources/org/sdmx/vtl/NegativeTests.vtl
@@ -1267,3 +1267,28 @@ DS_r := DS_1 [ sub Id_1 = 1  Id_2 = "A"]
 
 //nested clauses
 DS_r := DS_1 [ filter DS_2[sub id_1 = "AA"]];
+
+//two aggregate clauses are not allowed in a viral propagation
+define viral propagation EMBARGO_dup (variable EMBARGO_TIME) is
+aggregate max;
+aggregate min
+end viral propagation
+
+//an aggregation clause cannot be mixed with enumerated clauses
+define viral propagation CONF_mixed (variable CONF) is
+when "C" then "C";
+aggregate max
+end viral propagation
+
+//an aggregation clause cannot be combined with a default clause
+define viral propagation EMBARGO_else (variable EMBARGO_TIME) is
+aggregate max;
+else "F"
+end viral propagation
+
+//only one default clause is allowed in a viral propagation
+define viral propagation CONF_twodef (variable CONF) is
+when "C" then "C";
+else "F";
+else "G"
+end viral propagation

--- a/v2.2/src/test/resources/org/sdmx/vtl/PositiveTests.vtl
+++ b/v2.2/src/test/resources/org/sdmx/vtl/PositiveTests.vtl
@@ -1051,3 +1051,15 @@ DS_r:='ECB:EXR(1.0):....'[sub CURRENCY = "USD"];
 
 ## Start[TemporaryAssignment[VarID ClauseExpr[VarIdExpr[VarID] DatasetClause[SubspaceClause[SubspaceClauseItem[ComponentID SimpleScalar[IntegerLiteral[SignedInteger]]] SubspaceClauseItem[ComponentID SimpleScalar[StringLiteral]]]]]]]
 DS_r := _DS_1 [ sub _Id_1 = 1, _Id_2 = "A"];
+
+## Start[DefineExpression[DefViralPropagation[VarID VpSignature VpBody[EnumeratedVpClause[VpCondition[StringLiteral] StringLiteral] EnumeratedVpClause[VpCondition[StringLiteral] StringLiteral] DefaultVpClause[StringLiteral]]]]]
+define viral propagation CONF_priority (variable CONF) is
+when "C" then "C";
+when "N" then "N";
+else "F"
+end viral propagation;
+
+## Start[DefineExpression[DefViralPropagation[VarID VpSignature VpBody[AggregationVpClause]]]]
+define viral propagation EMBARGO_time (variable EMBARGO_TIME) is
+aggregate max
+end viral propagation;


### PR DESCRIPTION
A `vpBody` (`DEFINE VIRAL PROPAGATION`) now parses as **either** a single `aggregate` clause **or** a sequence of `when…then` clauses with an optional trailing `else`, matching the 2.2 reference manual. Previously the body was an unconstrained clause list, so two `aggregate` clauses — and other spec-invalid mixes — parsed.

**Changes**
- Grammar: split `vpClause` into `enumeratedVpClause` / `aggregationVpClause` / `defaultVpClause` and restructure `vpBody`.
- Docs: sync the `vpBody` BNF in `viral_attributes.rst`.
- Tests: 4 negative (two aggregates, aggregate+enumerated, aggregate+else, two else) and 2 positive (enumerated+else, single aggregate).